### PR TITLE
Support BelongsToManyOrigin (like MySQL with pivot table)

### DIFF
--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Str;
 use Jenssegers\Mongodb\Query\Builder as QueryBuilder;
+use Jenssegers\Mongodb\Relations\Pivot;
 use MongoDB\BSON\Binary;
 use MongoDB\BSON\ObjectID;
 use MongoDB\BSON\UTCDateTime;
@@ -420,6 +421,22 @@ abstract class Model extends BaseModel
         $connection = $this->getConnection();
 
         return new QueryBuilder($connection, $connection->getPostProcessor());
+    }
+
+    /**
+     * Create a new pivot model instance.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $parent
+     * @param  array  $attributes
+     * @param  string  $table
+     * @param  bool  $exists
+     * @param  string|null  $using
+     * @return \Illuminate\Database\Eloquent\Relations\Pivot
+     */
+    public function newPivot(BaseModel $parent, array $attributes, $table, $exists, $using = null)
+    {
+        return $using ? $using::fromRawAttributes($parent, $attributes, $table, $exists)
+            : Pivot::fromAttributes($parent, $attributes, $table, $exists);
     }
 
     /**

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -38,7 +38,7 @@ class Builder extends BaseBuilder
      * The pipeline stages.
      * @var array
      */
-    public $pipelineStages;
+    public $pipelineStages = [];
 
     /**
      * The cursor timeout value.
@@ -133,7 +133,6 @@ class Builder extends BaseBuilder
         $this->grammar = new Grammar;
         $this->connection = $connection;
         $this->processor = $processor;
-        $this->pipelineStages = [];
     }
 
     /**

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -450,6 +450,10 @@ class Builder extends BaseBuilder
         return md5(serialize(array_values($key)));
     }
 
+    /**
+     * Add a pipeline stage.
+     * @return $this
+     */
     public function addPipelineStage(array $stage)
     {
         $this->pipelineStages[] = $stage;

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -306,8 +306,13 @@ class Builder extends BaseBuilder
             $pipeline = [];
 
             if ($this->pipelineStages) {
-                foreach ($this->pipelineStages as $stage) {
-                    $pipeline[] = $stage;
+                foreach ($this->pipelineStages as $item) {
+                    list($method, $stage) = $item;
+                    if ($method !== 'unset') {
+                        $pipeline[] = [
+                            '$' . $method => $stage,
+                        ];
+                    }
                 }
             }
 
@@ -336,6 +341,17 @@ class Builder extends BaseBuilder
             }
             if ($this->projections) {
                 $pipeline[] = ['$project' => $this->projections];
+            }
+
+            if ($this->pipelineStages) {
+                foreach ($this->pipelineStages as $item) {
+                    list($method, $stage) = $item;
+                    if ($method === 'unset') {
+                        $pipeline[] = [
+                            '$unset' => $stage,
+                        ];
+                    }
+                }
             }
 
             $options = [
@@ -453,9 +469,9 @@ class Builder extends BaseBuilder
      * Add a pipeline stage.
      * @return $this
      */
-    public function addPipelineStage(array $stage)
+    public function addPipelineStage(string $method, $stage)
     {
-        $this->pipelineStages[] = $stage;
+        $this->pipelineStages[] = [$method, $stage];
         return $this;
     }
 

--- a/src/Relations/BelongsToManyOrigin.php
+++ b/src/Relations/BelongsToManyOrigin.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Jenssegers\Mongodb\Relations;
+
+use Illuminate\Database\Eloquent\Relations\BelongsToMany as EloquentBelongsToMany;
+
+class BelongsToManyOrigin extends EloquentBelongsToMany
+{
+    /**
+     * Set the select clause for the relation query.
+     * @param array $columns
+     * @return array
+     */
+    protected function getSelectColumns(array $columns = ['*'])
+    {
+        return $columns;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function shouldSelect(array $columns = ['*'])
+    {
+        return $columns;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function addConstraints()
+    {
+        if (static::$constraints) {
+            $this->setWhere();
+        }
+    }
+
+    /**
+     * Set the where clause for the relation query.
+     * @return $this
+     */
+    protected function setWhere()
+    {
+        $relatedPivotKey = $this->getQualifiedRelatedPivotKeyName();
+        $foreignPivotKey = $this->getQualifiedForeignPivotKeyName();
+
+        $this->query->addPipelineStage([
+            '$addFields' => [
+                'id' => [
+                    '$toString' => '$_id',
+                ],
+            ],
+        ])->addPipelineStage([
+            '$lookup' => [
+                'from' => $this->table,
+                'localField' => 'id',
+                'foreignField' => $relatedPivotKey,
+                'as' => 'pivot',
+            ],
+        ])->addPipelineStage([
+            '$unwind' => [
+                'path' => '$pivot',
+                'preserveNullAndEmptyArrays' => true,
+            ],
+        ])->addPipelineStage([
+            '$addFields' => [
+                "pivot_$relatedPivotKey" => '$pivot.' . $relatedPivotKey,
+                "pivot_$foreignPivotKey" => '$pivot.' . $foreignPivotKey,
+            ],
+        ])->addPipelineStage([
+            '$match' => [
+                "pivot.$foreignPivotKey" => $this->parent->getKey(),
+            ],
+        ])->addPipelineStage([
+            '$unset' => 'id',
+        ]);
+    }
+
+    public function get($columns = ['*'])
+    {
+        if ($this->pivotColumns) {
+            $addFields = [];
+            foreach ($this->pivotColumns as $column) {
+                $addFields["pivot_$column"] = '$pivot.' . $column;
+            }
+
+            $this->query->addPipelineStage([
+                '$addFields' => $addFields,
+            ]);
+        }
+        $this->query->addPipelineStage([
+            '$unset' => 'pivot',
+        ]);
+
+        return parent::get($columns);
+    }
+
+    /**
+     * Get the fully qualified foreign key for the relation.
+     * @return string
+     */
+    public function getForeignKey()
+    {
+        return $this->foreignPivotKey;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getQualifiedForeignPivotKeyName()
+    {
+        return $this->foreignPivotKey;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getQualifiedRelatedPivotKeyName()
+    {
+        return $this->relatedPivotKey;
+    }
+}

--- a/src/Relations/BelongsToManyOrigin.php
+++ b/src/Relations/BelongsToManyOrigin.php
@@ -64,10 +64,7 @@ class BelongsToManyOrigin extends EloquentBelongsToMany
                 ],
             ])
             ->addPipelineStage([
-                '$unwind' => [
-                    'path' => '$pivot',
-                    'preserveNullAndEmptyArrays' => true,
-                ],
+                '$unwind' => '$pivot',
             ]);
     }
 

--- a/src/Relations/Pivot.php
+++ b/src/Relations/Pivot.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Jenssegers\Mongodb\Relations;
+
+use DateTimeInterface;
+use Illuminate\Database\Eloquent\Relations\Pivot as EloquentPivot;
+use Illuminate\Support\Facades\Date;
+use MongoDB\BSON\UTCDateTime;
+
+class Pivot extends EloquentPivot
+{
+    /**
+     * @inheritdoc
+     */
+    public function fromDateTime($value)
+    {
+        // If the value is already a UTCDateTime instance, we don't need to parse it.
+        if ($value instanceof UTCDateTime) {
+            return $value;
+        }
+
+        // Let Eloquent convert the value to a DateTime instance.
+        if (!$value instanceof DateTimeInterface) {
+            $value = parent::asDateTime($value);
+        }
+
+        return new UTCDateTime($value->format('Uv'));
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function asDateTime($value)
+    {
+        // Convert UTCDateTime instances.
+        if ($value instanceof UTCDateTime) {
+            $date = $value->toDateTime();
+
+            $seconds = $date->format('U');
+            $milliseconds = abs($date->format('v'));
+            $timestampMs = sprintf('%d%03d', $seconds, $milliseconds);
+
+            return Date::createFromTimestampMs($timestampMs);
+        }
+
+        return parent::asDateTime($value);
+    }
+}


### PR DESCRIPTION
Support BelongsToManyOrigin (like MySQL with pivot table)

```
class Post extends Model
{
    protected $table = 'post';

    public function tags()
    {
        return $this->belongsToManyOrigin(Tag::class, 'post_tag', 'post_id', 'tag_id');
    }
}

class Tag extends Model
{
    protected $table = 'tag';

    public function posts()
    {
        return $this->belongsToManyOrigin(Post::class, 'post_tag', 'tag_id', 'post_id');
    }
}
```